### PR TITLE
Servant & acid state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 # Haskell build files
 .stack-work/
+
+# Generated from package.yml by hpack
 shrtn.cabal
+
+# Default acid-state directory
+shrtn.state/

--- a/package.yaml
+++ b/package.yaml
@@ -6,12 +6,16 @@ version: 0.1.0.0
 ghc-options: -Wall -O2
 
 dependencies:
+  - acid-state < 0.15
   - aeson < 1.2
   - async < 2.2
   - base >= 4.7 && < 5
   - http-types < 0.10
+  - mtl < 2.3
   - servant-server < 0.12
+  - safecopy < 0.15
   - text < 1.3
+  - unordered-containers < 0.3
   - wai < 3.3
   - warp < 3.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -6,8 +6,11 @@ version: 0.1.0.0
 ghc-options: -Wall -O2
 
 dependencies:
+  - aeson < 1.2
   - base >= 4.7 && < 5
   - http-types < 0.10
+  - servant-server < 0.12
+  - text < 1.3
   - wai < 3.3
   - warp < 3.3
 

--- a/package.yaml
+++ b/package.yaml
@@ -7,6 +7,7 @@ ghc-options: -Wall -O2
 
 dependencies:
   - aeson < 1.2
+  - async < 2.2
   - base >= 4.7 && < 5
   - http-types < 0.10
   - servant-server < 0.12

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -7,33 +7,56 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE TypeOperators #-}
+{-# LANGUAGE TypeFamilies #-}
+
 
 module Main where
 
 import qualified Control.Concurrent.Async as Async
+import qualified Control.Monad.State as State
+import qualified Control.Monad.Reader as Reader
+import qualified Data.Acid as Acid
+import qualified Data.Acid.Advanced as Acid
 import qualified Data.Aeson as Aeson
+import qualified Data.HashMap.Strict as HM
 import qualified Data.Text as T
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
 
+import qualified Data.SafeCopy as SC
+
+import Data.Maybe
+
+import Control.Monad.State (State)
+import Data.Acid (AcidState(..))
+import Data.Acid.Advanced (IsAcidic(..), Event(QueryEvent, UpdateEvent))
+import Data.Acid.Core (Method(..))
+import Data.SafeCopy (SafeCopy)
 import GHC.Generics (Generic)
+
+import Data.Typeable
 import Servant
 
 main :: IO ()
 main = do
+  state <- openState
+
   let
     app =
       Warp.runSettings
         (settings 7000)
-        shrtnApp
+        (shrtnApp state)
     admin =
       Warp.runSettings
         (settings 7001)
-        mngmntApp
+        (mngmntApp state)
 
   foldr1 Async.race_ [app, admin]
+
+-- Warp
 
 settings :: Int -> Warp.Settings
 settings port
@@ -41,32 +64,103 @@ settings port
   $ Warp.setHost "*"
   $ Warp.defaultSettings
 
-shrtnApp :: Wai.Application
-shrtnApp _request respond =
+shrtnApp :: AcidState ST -> Wai.Application
+shrtnApp _state _request respond =
   respond $
     Wai.responseLBS
       HTTP.status200
       []
       "Things are working pretty nicely."
 
-mngmntApp :: Wai.Application
-mngmntApp =
+mngmntApp :: AcidState ST -> Wai.Application
+mngmntApp state =
   Servant.serve
     (Proxy :: Proxy Mngmnt)
-    mngmnt
+    (mngmnt state)
+
+-- State
+
+type Key = T.Text
+type Value = T.Text
+data ST = ST !(HM.HashMap Key Value)
+  deriving (Typeable)
+
+instance SafeCopy ST where
+  putCopy state = SC.contain $ SC.safePut state
+  getCopy = SC.contain $ SC.safeGet
+
+insertKey :: Key -> Value -> Acid.Update ST ()
+insertKey key value = do
+  ST current <- State.get
+  State.put $ ST $ HM.insert key value current
+
+lookupKey :: Key -> Acid.Query ST (Maybe Value)
+lookupKey key = do
+  ST current <- Reader.ask
+  return $ HM.lookup key current
+
+data InsertKey = InsertKey Key Value
+data LookupKey = LookupKey Key
+
+deriving instance Typeable InsertKey
+instance SafeCopy InsertKey where
+  putCopy (InsertKey key value) = SC.contain $ SC.safePut key >> SC.safePut value
+  getCopy = SC.contain $ InsertKey <$> SC.safeGet <*> SC.safeGet
+
+instance Method InsertKey where
+    type MethodResult InsertKey = ()
+    type MethodState InsertKey = ST
+instance Acid.UpdateEvent InsertKey
+
+deriving instance Typeable LookupKey
+instance SafeCopy LookupKey where
+    putCopy (LookupKey key) = SC.contain $ SC.safePut key
+    getCopy = SC.contain $ LookupKey <$> SC.safeGet
+instance Method LookupKey where
+    type MethodResult LookupKey = Maybe Value
+    type MethodState LookupKey = ST
+instance Acid.QueryEvent LookupKey
+
+instance IsAcidic ST where
+  acidEvents = [ UpdateEvent (\(InsertKey key value) -> insertKey key value)
+               , QueryEvent (\(LookupKey key) -> lookupKey key)
+               ]
+
+openState :: IO (AcidState ST)
+openState =
+  let
+    path = "shrtn.state"
+    empty = ST $ HM.empty
+  in
+    Acid.openLocalStateFrom
+      path
+      empty
+
+-- Servant
 
 type Mngmnt
-  = "shorten"
-    :> ReqBody '[JSON] CreateReq
-    :> Post '[JSON] NoContent
+  = "shorten" :> ReqBody '[JSON] CreateReq :> Post '[JSON] NoContent
+   :<|> "list" :> Get '[JSON] Aliases
 
 data CreateReq = CreateReq
   { url :: T.Text
   , alias :: Maybe T.Text
   } deriving (Generic, Aeson.FromJSON)
 
-mngmnt :: Server Mngmnt
-mngmnt = createRoute
+data Aliases = Aliases
+  { dest :: T.Text
+  , short :: T.Text
+  } deriving (Generic, Aeson.ToJSON)
 
-createRoute :: CreateReq -> Handler NoContent
-createRoute _request = pure NoContent
+mngmnt :: AcidState ST -> Server Mngmnt
+mngmnt state = (createRoute state) :<|> (listRoute state)
+
+listRoute :: AcidState ST -> Handler Aliases
+listRoute state = do
+  new <- Acid.query' state (LookupKey "blah")
+  return $ Aliases { dest = "blah", short = fromJust new }
+
+createRoute :: AcidState ST -> CreateReq -> Handler NoContent
+createRoute state _request = do
+  newState <- Acid.update' state (InsertKey "blah" "asdfasdf")
+  pure NoContent

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -10,7 +10,7 @@ main :: IO ()
 main = do
   Warp.runSettings
     shrtnSettings
-    shrtn
+    shrtnApp
 
 shrtnSettings :: Warp.Settings
 shrtnSettings
@@ -18,8 +18,8 @@ shrtnSettings
   $ Warp.setHost "*"
   $ Warp.defaultSettings
 
-shrtn :: Wai.Application
-shrtn _request respond =
+shrtnApp :: Wai.Application
+shrtnApp _request respond =
   respond $
     Wai.responseLBS
       HTTP.status200

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -11,6 +11,7 @@
 
 module Main where
 
+import qualified Control.Concurrent.Async as Async
 import qualified Data.Aeson as Aeson
 import qualified Data.Text as T
 import qualified Network.HTTP.Types as HTTP
@@ -22,13 +23,21 @@ import Servant
 
 main :: IO ()
 main = do
-  Warp.runSettings
-    shrtnSettings
-    shrtnApp
+  let
+    app =
+      Warp.runSettings
+        (settings 7000)
+        shrtnApp
+    admin =
+      Warp.runSettings
+        (settings 7001)
+        mngmntApp
 
-shrtnSettings :: Warp.Settings
-shrtnSettings
-  = Warp.setPort 7000
+  foldr1 Async.race_ [app, admin]
+
+settings :: Int -> Warp.Settings
+settings port
+  = Warp.setPort port
   $ Warp.setHost "*"
   $ Warp.defaultSettings
 

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -46,12 +46,18 @@ mngmntApp =
     (Proxy :: Proxy Mngmnt)
     mngmnt
 
+type Mngmnt
+  = "shorten"
+    :> ReqBody '[JSON] CreateReq
+    :> Post '[JSON] NoContent
+
 data CreateReq = CreateReq
   { url :: T.Text
   , alias :: Maybe T.Text
   } deriving (Generic, Aeson.FromJSON)
 
-type Mngmnt = "shorten" :> ReqBody '[JSON] CreateReq :> Post '[JSON] NoContent
-
 mngmnt :: Server Mngmnt
-mngmnt = undefined
+mngmnt = createRoute
+
+createRoute :: CreateReq -> Handler NoContent
+createRoute _request = pure NoContent

--- a/src/Main.hs
+++ b/src/Main.hs
@@ -1,10 +1,24 @@
+{-# LANGUAGE DataKinds #-}
+{-# LANGUAGE DeriveGeneric #-}
+{-# LANGUAGE DeriveAnyClass #-}
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators #-}
 
 module Main where
 
+import qualified Data.Aeson as Aeson
+import qualified Data.Text as T
 import qualified Network.HTTP.Types as HTTP
 import qualified Network.Wai as Wai
 import qualified Network.Wai.Handler.Warp as Warp
+
+import GHC.Generics (Generic)
+import Servant
 
 main :: IO ()
 main = do
@@ -25,3 +39,19 @@ shrtnApp _request respond =
       HTTP.status200
       []
       "Things are working pretty nicely."
+
+mngmntApp :: Wai.Application
+mngmntApp =
+  Servant.serve
+    (Proxy :: Proxy Mngmnt)
+    mngmnt
+
+data CreateReq = CreateReq
+  { url :: T.Text
+  , alias :: Maybe T.Text
+  } deriving (Generic, Aeson.FromJSON)
+
+type Mngmnt = "shorten" :> ReqBody '[JSON] CreateReq :> Post '[JSON] NoContent
+
+mngmnt :: Server Mngmnt
+mngmnt = undefined

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,1 +1,4 @@
 resolver: lts-9.10
+extra-deps:
+  - acid-state-0.14.3
+  - safecopy-0.9.3.3


### PR DESCRIPTION
This PR adds:

 - A Servant route definition for the admin API.
 - A skeleton for durability thanks to `acid-state`